### PR TITLE
Update 第七章：错误处理.md

### DIFF
--- a/docs/第七章：错误处理.md
+++ b/docs/第七章：错误处理.md
@@ -111,7 +111,7 @@ def internal_error(error):
 这两个模板都从`base.html`基础模板继承而来，所以错误页面与应用的普通页面有相同的外观布局。
 
 为了让这些错误处理程序在Flask中注册，我需要在应用实例创建后导入新的*app/errors.py*模块。
-app/__init__.py：
+app/\_\_init\_\_.py：
 ```
 # ...
 


### PR DESCRIPTION
__init__.py文件名下划线未转义，导致文章内显示文件名错误